### PR TITLE
Fix refresh token API routing

### DIFF
--- a/app/api/auth/refresh/route.ts
+++ b/app/api/auth/refresh/route.ts
@@ -6,7 +6,7 @@ export async function POST(req: NextRequest) {
   try {
     const { refresh_token } = await req.json();
     if (!refresh_token) {
-      return NextResponse.json({ error: 'Missins refresh token' }, { status: 400 });
+      return NextResponse.json({ error: 'Missing refresh token' }, { status: 400 });
     }
 
     const clientId = process.env.NEXT_PUBLIC_SPOTIFY_CLIENT_ID!;

--- a/app/callback/page.tsx
+++ b/app/callback/page.tsx
@@ -11,33 +11,12 @@ export default function Callback() {
   useEffect(() => {
     const code = searchParams.get('code');
     if (code) {
-      exchangeToken(code);
       saveTokenData(code);
     } else {
       setError('No authorization code found');
     }
   }, []);
 
-  const exchangeToken = async (code: string) => {
-    try {
-      const response = await fetch('/api/auth/token', {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ code }),
-      });
-      const data = await response.json();
-
-      if (data.access_token) {
-        sessionStorage.setItem('access_token', data.access_token);
-        router.push('/');
-      } else {
-        setError('Failed to obtain access token');
-      }
-    } catch (err) {
-      setError(`An error occurred while exchangeing token: ${err}`);
-      console.error(err);
-    }
-  };
 
   const saveTokenData = async (code: string) => {
     const codeVerifier = sessionStorage.getItem('codeVerifier');
@@ -58,7 +37,7 @@ export default function Callback() {
         setError('Failed to obtain access token');
       }
     } catch (err) {
-      setError(`An error occurred while exchangeing token: ${err}`);
+      setError(`An error occurred while exchanging token: ${err}`);
       console.error(err);
     }
   };


### PR DESCRIPTION
## Summary
- enable refresh token API handler by placing it under `refresh/route.ts`
- clean up callback page to avoid extra token exchange and fix typo

## Testing
- `npm run lint` *(fails: `next` not found)*
- `npm run typecheck` *(fails: missing dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_68663fcb190c8328b701811c361c1a7a